### PR TITLE
fix: 使えないhookブロックとCLIフラグを撤廃

### DIFF
--- a/claude/hooks/validate-tool-use.sh
+++ b/claude/hooks/validate-tool-use.sh
@@ -2,29 +2,8 @@
 INPUT=$(cat)
 COMMAND=$(printf '%s\n' "$INPUT" | jq -r '.tool_input.command')
 
-# grep / rg → Grep ツール
-if echo "$COMMAND" | grep -qE '^\s*(grep|rg|egrep|fgrep)\b'; then
-  echo "Blocked: grep/rg は Grep ツールを使ってください。" >&2
-  exit 2
-fi
-
-# find / ls → Glob ツール
-if echo "$COMMAND" | grep -qE '^\s*(find|ls)\b'; then
-  echo "Blocked: find/ls は Glob ツールを使ってください。" >&2
-  exit 2
-fi
-
-# cat / head / tail（ファイル読み取り）→ Read ツール
-if echo "$COMMAND" | grep -qE '^\s*(cat|head|tail)\b'; then
-  echo "Blocked: cat/head/tail は Read ツールを使ってください。" >&2
-  exit 2
-fi
-
-# sed / awk（ファイル編集）→ Edit ツール
-if echo "$COMMAND" | grep -qE '^\s*(sed|awk)\b'; then
-  echo "Blocked: sed/awk は Edit ツールを使ってください。" >&2
-  exit 2
-fi
+# grep/rg, find/ls, cat/head/tail, sed/awk のブロックは無効化中
+# （Grep/Globツールが配布されないセッションがあり、代替不可能な詰みが発生するため）
 
 # python3 -m json.tool をブロックし jq empty を案内
 if echo "$COMMAND" | grep -qE 'python3?\s+-m\s+json\.tool'; then

--- a/zsh/plugins/claude
+++ b/zsh/plugins/claude
@@ -13,6 +13,6 @@ function reset-keyboard-protocol() {
 }
 
 function claude() {
-  command claude --enable-auto-mode "$@"
+  command claude "$@"
   reset-keyboard-protocol
 }


### PR DESCRIPTION
## 概要

- Grep/Globツールが配布されないセッションでBashのgrep/find/cat/sedブロックが代替不能な詰みを生んでいたため無効化
- claude()関数の--permission-mode autoフラグを撤廃（settings.jsonのdefaultMode=autoで代替）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Common shell commands such as searching, listing, viewing, and processing files are no longer blocked by tool-use validation.
  * The Claude command no longer enables automatic mode by default.
  * Existing argument forwarding and validation behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->